### PR TITLE
Module Deletion

### DIFF
--- a/Source/lib/Connections.cpp
+++ b/Source/lib/Connections.cpp
@@ -149,7 +149,6 @@ void Connections::actionListenerCallback (const String& message)
         
         createConnection(stringToIOid(inletIdString), stringToIOid(outletIdString));
         updateAllConnectionPaths();
-        sendChangeMessage(); // notify new connections
     }
 }
 
@@ -173,6 +172,20 @@ void Connections::createConnection(const IOid inletId, const IOid outletId)
                          , getInletCenterPositionFromId(inletId)
                          , getOutletCenterPositionFromId(outletId)));
     }
+    sendChangeMessage(); // notify new connections
+}
+
+void Connections::removeModule(uint32 moduleId)
+{
+    for (Connection* connection : connections)
+    {
+        if (connection->inletId.first == moduleId || connection->outletId.first == moduleId)
+        {
+            connections.removeObject(connection);
+        }
+    }
+    idStore.removeModule(moduleId);
+    updateAllConnectionPaths();
 }
 
 Array<std::pair<Connections::IOid, Connections::IOid>> Connections::getAllConnectionIdPairs()

--- a/Source/lib/Connections.cpp
+++ b/Source/lib/Connections.cpp
@@ -177,12 +177,14 @@ void Connections::createConnection(const IOid inletId, const IOid outletId)
 
 void Connections::removeModule(uint32 moduleId)
 {
-    for (Connection* connection : connections)
+    int i = 0;
+    while (i < connections.size())
     {
-        if (connection->inletId.first == moduleId || connection->outletId.first == moduleId)
+        if (connections[i]->inletId.first == moduleId || connections[i]->outletId.first == moduleId)
         {
-            connections.removeObject(connection);
+            connections.remove(i);
         }
+        else i++;
     }
     idStore.removeModule(moduleId);
     updateAllConnectionPaths();

--- a/Source/lib/Connections.h
+++ b/Source/lib/Connections.h
@@ -39,6 +39,8 @@ public:
     
     Array<std::pair<IOid, IOid>> getAllConnectionIdPairs();
     
+    void removeModule(uint32);
+    
     void togglePatchCordType();
 
 private:
@@ -84,6 +86,11 @@ private:
         {
             if (outlets.find(nodeId) == outlets.end()) return 0;
             return outlets[nodeId].rbegin()->first + 1;
+        }
+        
+        void removeModule (const uint32 nodeId)
+        {
+            inlets.erase(nodeId);
         }
         
     } idStore;

--- a/Source/lib/Connections.h
+++ b/Source/lib/Connections.h
@@ -91,6 +91,7 @@ private:
         void removeModule (const uint32 nodeId)
         {
             inlets.erase(nodeId);
+            outlets.erase(nodeId);
         }
         
     } idStore;

--- a/Source/lib/MainPatcher.cpp
+++ b/Source/lib/MainPatcher.cpp
@@ -87,9 +87,9 @@ void MainPatcher::mouseDown(const MouseEvent& e)
 
 void MainPatcher::deleteModule(ModuleBox* moduleBox)
 {
+    connections.removeModule(moduleBox->module->nodeID.uid);
     mainProcessor->removeNode(moduleBox->module->nodeID);
     modules.removeObject(moduleBox);
-    connections.removeModule(moduleBox->module->nodeID.uid);
 }
 
 void MainPatcher::deleteAllSelectedModules()

--- a/Source/lib/MainPatcher.cpp
+++ b/Source/lib/MainPatcher.cpp
@@ -15,6 +15,8 @@
 MainPatcher::MainPatcher() :
 mainProcessor{std::make_unique<AudioProcessorGraph>()}
 {
+    setWantsKeyboardFocus(true);
+    
     // Menu and submenus content
     // Submenus must be filled before the main
     modulesSubMenu.addItem (1, "Impulse");
@@ -83,6 +85,28 @@ void MainPatcher::mouseDown(const MouseEvent& e)
     }
 }
 
+void MainPatcher::deleteModule(ModuleBox* moduleBox)
+{
+    mainProcessor->removeNode(moduleBox->module->nodeID);
+    modules.removeObject(moduleBox);
+    connections.removeModule(moduleBox->module->nodeID.uid);
+}
+
+void MainPatcher::deleteAllSelectedModules()
+{
+    for (int i=0; i < selectedModules.getNumSelected(); i++)
+        deleteModule(selectedModules.getSelectedItem(i));
+}
+
+bool MainPatcher::keyPressed (const KeyPress& key)
+{
+    if (key == KeyPress::backspaceKey)
+    {
+        deleteAllSelectedModules();
+    }
+    return true;
+}
+
 void MainPatcher::togglePatchCordType()
 {
     connections.togglePatchCordType();
@@ -140,6 +164,8 @@ void MainPatcher::createModule(Point<float> position)
             mainProcessor->addConnection ({ { newNode->nodeID, i }, { outputNode->nodeID, i } });
         }
     }
+    
+    modulePtr->nodeID = newNode->nodeID;
     
     registerInletsAndOutlets(modulePtr, newNode.get()->nodeID.uid);
 }

--- a/Source/lib/MainPatcher.h
+++ b/Source/lib/MainPatcher.h
@@ -46,6 +46,8 @@ public:
     
     std::unique_ptr<AudioProcessorGraph> mainProcessor;
     
+    bool keyPressed (const KeyPress& key) override;
+    
 private:
     
     AudioDeviceManager deviceManager;
@@ -71,6 +73,9 @@ private:
     
     template <class moduleClass>
     void createModule(Point<float>);
+    
+    void deleteModule(ModuleBox*);
+    void deleteAllSelectedModules();
     
     void applyAudioConnections();
     

--- a/Source/lib/Module.h
+++ b/Source/lib/Module.h
@@ -40,6 +40,8 @@ public:
     
     Props props;
     
+    AudioProcessorGraph::NodeID nodeID;
+    
     const Rectangle<int> placeInletsOutlets (Rectangle<int>);
     
     /**

--- a/Source/lib/ModuleBox.cpp
+++ b/Source/lib/ModuleBox.cpp
@@ -43,6 +43,7 @@ moduleSelection{selectionChangeSource}
 
 ModuleBox::~ModuleBox()
 {
+    moduleSelection.removeChangeListener(this);
     setLookAndFeel (nullptr);
 }
 


### PR DESCRIPTION
Solves #1 

Module deletion is triggered by ⌫

Deletes visual connections and `AudioProcessorGraph` nodes and connections.

Unsubscribes from `selectedModules` and deletes the entries in `Connections::idStore`

All selected modules are deleted;

Yaaay, first PR!