### PR TITLE
Prevent modules from connecting to themselves

### DIFF
--- a/Source/lib/Plug.cpp
+++ b/Source/lib/Plug.cpp
@@ -94,7 +94,20 @@ void Plug::mouseDrag(const MouseEvent& e)
 
 bool Plug::isInterestedInDragSource (const SourceDetails& dragSourceDetails)
 {
-    return dragSourceDetails.description.toString().contains(modeString.second);
+    String sourceDetailsString =  dragSourceDetails.description.toString();
+    if (sourceDetailsString.startsWith(modeString.second))
+    {
+        uint32 receivedModuleID = sourceDetailsString.fromFirstOccurrenceOf(modeString.second, false, false)
+                                                     .upToFirstOccurrenceOf(">", false, false)
+                                                     .toUTF8().getIntValue32();
+        
+        // Not interested if the connection is from the same module
+        if (receivedModuleID != moduleID)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 void Plug::itemDropped (const SourceDetails& dragSourceDetails)

--- a/Source/lib/Plug.cpp
+++ b/Source/lib/Plug.cpp
@@ -101,11 +101,8 @@ bool Plug::isInterestedInDragSource (const SourceDetails& dragSourceDetails)
                                                      .upToFirstOccurrenceOf(">", false, false)
                                                      .toUTF8().getIntValue32();
         
-        // Not interested if the connection is from the same module
-        if (receivedModuleID != moduleID)
-        {
-            return true;
-        }
+        // Only interested if the connection is from a different module
+        if (receivedModuleID != moduleID) return true;
     }
     return false;
 }

--- a/Source/lib/Plug.cpp
+++ b/Source/lib/Plug.cpp
@@ -94,10 +94,10 @@ void Plug::mouseDrag(const MouseEvent& e)
 
 bool Plug::isInterestedInDragSource (const SourceDetails& dragSourceDetails)
 {
-    String sourceDetailsString =  dragSourceDetails.description.toString();
-    if (sourceDetailsString.startsWith(modeString.second))
+    String sourceString =  dragSourceDetails.description.toString();
+    if (sourceString.startsWith(modeString.second))
     {
-        uint32 receivedModuleID = sourceDetailsString.fromFirstOccurrenceOf(modeString.second, false, false)
+        uint32 receivedModuleID = sourceString.fromFirstOccurrenceOf(modeString.second, false, false)
                                                      .upToFirstOccurrenceOf(">", false, false)
                                                      .toUTF8().getIntValue32();
         


### PR DESCRIPTION
Closes #9 

This was implemented in `Plug::isInterestedInDragSource` and verifies that the dragged connection does not belong to the same module as itself before claiming interest.