### PR TITLE
Use NormalisableRange and skewFactor in Dial

### DIFF
--- a/Source/lib/UIobjects/ui_Dial.cpp
+++ b/Source/lib/UIobjects/ui_Dial.cpp
@@ -13,15 +13,17 @@
 ///@endcond
 #include "ui_Dial.h"
 
-ui_Dial::ui_Dial(float rangeLow, float rangeHigh, std::string valueSuffix, int decimals, Slider::Listener* listener)
+ui_Dial::ui_Dial(float rangeLow, float rangeHigh, Slider::Listener* listener, double skewFactor, std::string valueSuffix, int decimals) :
+valueRange{rangeLow, rangeHigh, 0, skewFactor}
 {
-    setRange                     (rangeLow, rangeHigh);
-    setTextValueSuffix           (valueSuffix);
-    addListener                  (listener);
+    setNormalisableRange         (valueRange);
     setSliderStyle               (RotaryVerticalDrag);
     setTextBoxStyle              (TextBoxBelow, true, 80, 20);
-    setNumDecimalPlacesToDisplay (decimals);
     setTextBoxIsEditable         (true);
+    
+    setTextValueSuffix           (valueSuffix);
+    setNumDecimalPlacesToDisplay (decimals);
+    addListener                  (listener);
     
     setPaintingIsUnclipped (true);
     
@@ -75,7 +77,7 @@ void ui_Dial::lookAndFeelChanged ()
 
 void ui_Dial::updateDial ()
 {
-    angle = startAngle + (getValue()-getMinimum())/getRange().getLength() * range;
+    angle = startAngle + valueRange.convertTo0to1(getValue()) * angleRange;
     
     dial.clear();
     dial.addCentredArc(box.getCentreX(), box.getCentreY(), radius, radius, 0, startAngle, angle, true);

--- a/Source/lib/UIobjects/ui_Dial.h
+++ b/Source/lib/UIobjects/ui_Dial.h
@@ -21,7 +21,7 @@ class ui_Dial    : public Slider,
                    public Slider::Listener
 {
 public:
-    ui_Dial(float, float, std::string, int, Slider::Listener*);
+    ui_Dial(float, float, Slider::Listener*, double = 1, std::string = "", int = 2);
     ~ui_Dial();
     
     void paint (Graphics& g) override;
@@ -30,6 +30,8 @@ public:
     void lookAndFeelChanged() override;
     
 private:
+    
+    NormalisableRange<double> valueRange;
     
     Path groove;
     Path dial;
@@ -44,7 +46,7 @@ private:
     const int thickness = 5;
     const float startAngle = getRotaryParameters().startAngleRadians;
     const float endAngle = getRotaryParameters().endAngleRadians;
-    const float range = endAngle - startAngle;
+    const float angleRange = endAngle - startAngle;
     
     float size;
     float radius;

--- a/Source/lib/modules/module_Gain.cpp
+++ b/Source/lib/modules/module_Gain.cpp
@@ -23,7 +23,7 @@ Module{{
     .height = 150,
     .minimumHeight = 100
 }},
-gainDial(-70, 12, " dB", 2, this)
+gainDial(-70, 12, this, 1, " dB")
 {
     addAndMakeVisible(gainDial);
 }

--- a/Source/lib/modules/module_Impulse.cpp
+++ b/Source/lib/modules/module_Impulse.cpp
@@ -24,13 +24,13 @@ Module{{
     .height = 200,
     .minimumHeight = 100
 }},
-decayDial(5, 100, " ms", 2, this),
-shapeDial(0, 1, " %", 0, this)
+frequencyDial(20, 20000, this, 0.33, " Hz"),
+shapeDial(0, 1, this, 1, " %", 0)
 {
     shapeDial.textFromValueFunction = [] (float f) -> String { return String(int(f * 100)); };
     shapeDial.valueFromTextFunction = [] (String s) -> float { return float(s.toUTF8().getDoubleValue()) * 0.01; };
 
-    addAndMakeVisible(decayDial);
+    addAndMakeVisible(frequencyDial);
     addAndMakeVisible(shapeDial);
 }
 
@@ -149,12 +149,12 @@ void module_Impulse::wasResized(Rectangle<int> moduleBounds)
 {
     // Place the Dials
     Rectangle<int> dialBounds = moduleBounds.removeFromLeft(getWidth()*0.25);
-    decayDial.setBounds( dialBounds.removeFromTop(getHeight()*0.5));
+    frequencyDial.setBounds( dialBounds.removeFromTop(getHeight()*0.5));
     shapeDial.setBounds( dialBounds.removeFromBottom(getHeight()*0.5));
     
     // Place the waveform and update
     waveForm.setViewPort(moduleBounds.reduced(10,0).toFloat());
-    waveForm.updateForm(shapeDial.getValue(), decayDial.getValue());
+    waveForm.updateForm(shapeDial.getValue(), frequencyDial.getValue());
 }
 
 void module_Impulse::lookAndFeelChanged()
@@ -162,7 +162,7 @@ void module_Impulse::lookAndFeelChanged()
     waveForm.setColour(findColour(Slider::thumbColourId));
 }
 
-void module_Impulse::decayDialChanged (float value)
+void module_Impulse::frequencyDialChanged (float value)
 {
 }
 
@@ -172,16 +172,16 @@ void module_Impulse::shapeDialChanged (float value)
 
 void module_Impulse::sliderValueChanged (Slider* slider)
 {
-    bool isDecay = slider == &decayDial;
+    bool isDecay = slider == &frequencyDial;
     bool isShape = slider == &shapeDial;
     if (isDecay || isShape)
     {
         if (isDecay){
-            decayDialChanged(slider->getValue());
+            frequencyDialChanged(slider->getValue());
         } else if (isShape){
             shapeDialChanged(slider->getValue()*0.01);
         }
-        waveForm.updateForm(shapeDial.getValue(), decayDial.getValue());
+        waveForm.updateForm(shapeDial.getValue(), frequencyDial.getValue());
         repaint();
     }
     

--- a/Source/lib/modules/module_Impulse.h
+++ b/Source/lib/modules/module_Impulse.h
@@ -39,7 +39,7 @@ public:
 private:
     
     //Dials
-    ui_Dial decayDial;
+    ui_Dial frequencyDial;
     ui_Dial shapeDial;
     
     //Waveform
@@ -63,7 +63,7 @@ private:
     
     //Listeners
     void sliderValueChanged (Slider*) override;
-    void decayDialChanged (float value);
+    void frequencyDialChanged (float value);
     void shapeDialChanged (float value);
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (module_Impulse)


### PR DESCRIPTION
This alters the Dial constructor to include the option for a Skew Factor.
This uses a `NormalisableRange` member internally to do the conversion.